### PR TITLE
feat: Add stats and support for mocking

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+indent_size=4

--- a/GOGDotNet.Tests/GOGClientTests.cs
+++ b/GOGDotNet.Tests/GOGClientTests.cs
@@ -1,25 +1,42 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace GOGDotNet.Tests
 {
-    [TestClass]
-    public class GOGClientTests
+  [TestClass]
+  public class GOGClientTests
+  {
+    private GOGClient client;
+
+    [TestInitialize]
+    public void TestInitialize()
     {
-        private GOGClient client;
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            this.client = new GOGClient();
-        }
-
-        [TestMethod]
-        public async Task GetGameStats()
-        {
-            const string userID = "MChartier";
-            var response = await this.client.GetGamesStatsAsync(userID);
-            Assert.IsNotNull(response);
-        }
+      this.client = new GOGClient();
     }
+
+    [TestMethod]
+    public async Task GetGameStats()
+    {
+      const string userID = "MChartier";
+      var response = await this.client.GetGamesStatsAsync(userID);
+      Assert.IsNotNull(response);
+      Assert.AreEqual(response.Item1, Models.ProfileState.Verified);
+
+      var games = response.Item2.ToList();
+      var discoElysium = games.FirstOrDefault(g => g.Id == 1771589310);
+
+      Assert.IsNotNull(discoElysium);
+      Assert.IsTrue(discoElysium.AchievementSupport);
+      Assert.IsTrue(discoElysium.Playtime > 0);
+      Assert.IsTrue(discoElysium.AchievementPercentage > 0);
+      Assert.IsTrue(discoElysium.LastSession > DateTime.MinValue);
+
+      var sevenBillionHumans = games.FirstOrDefault(g => g.Id == 2056114425);
+      Assert.IsNotNull(sevenBillionHumans);
+      Assert.IsFalse(sevenBillionHumans.AchievementSupport);
+      Assert.IsNull(sevenBillionHumans.AchievementPercentage);
+    }
+  }
 }

--- a/GOGDotNet.Tests/GOGClientTests.cs
+++ b/GOGDotNet.Tests/GOGClientTests.cs
@@ -5,38 +5,38 @@ using System.Threading.Tasks;
 
 namespace GOGDotNet.Tests
 {
-  [TestClass]
-  public class GOGClientTests
-  {
-    private GOGClient client;
-
-    [TestInitialize]
-    public void TestInitialize()
+    [TestClass]
+    public class GOGClientTests
     {
-      this.client = new GOGClient();
+        private GOGClient client;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this.client = new GOGClient();
+        }
+
+        [TestMethod]
+        public async Task GetGameStats()
+        {
+            const string userID = "MChartier";
+            var response = await this.client.GetGamesStatsAsync(userID);
+            Assert.IsNotNull(response);
+            Assert.AreEqual(response.Item1, Models.ProfileState.Verified);
+
+            var games = response.Item2.ToList();
+            var discoElysium = games.FirstOrDefault(g => g.Id == 1771589310);
+
+            Assert.IsNotNull(discoElysium);
+            Assert.IsTrue(discoElysium.AchievementSupport);
+            Assert.IsTrue(discoElysium.Playtime > 0);
+            Assert.IsTrue(discoElysium.AchievementsPercentage > 0);
+            Assert.IsTrue(discoElysium.LastSession > DateTime.MinValue);
+
+            var sevenBillionHumans = games.FirstOrDefault(g => g.Id == 2056114425);
+            Assert.IsNotNull(sevenBillionHumans);
+            Assert.IsFalse(sevenBillionHumans.AchievementSupport);
+            Assert.IsNull(sevenBillionHumans.AchievementsPercentage);
+        }
     }
-
-    [TestMethod]
-    public async Task GetGameStats()
-    {
-      const string userID = "MChartier";
-      var response = await this.client.GetGamesStatsAsync(userID);
-      Assert.IsNotNull(response);
-      Assert.AreEqual(response.Item1, Models.ProfileState.Verified);
-
-      var games = response.Item2.ToList();
-      var discoElysium = games.FirstOrDefault(g => g.Id == 1771589310);
-
-      Assert.IsNotNull(discoElysium);
-      Assert.IsTrue(discoElysium.AchievementSupport);
-      Assert.IsTrue(discoElysium.Playtime > 0);
-      Assert.IsTrue(discoElysium.AchievementPercentage > 0);
-      Assert.IsTrue(discoElysium.LastSession > DateTime.MinValue);
-
-      var sevenBillionHumans = games.FirstOrDefault(g => g.Id == 2056114425);
-      Assert.IsNotNull(sevenBillionHumans);
-      Assert.IsFalse(sevenBillionHumans.AchievementSupport);
-      Assert.IsNull(sevenBillionHumans.AchievementPercentage);
-    }
-  }
 }

--- a/GOGDotNet/GOGClient.cs
+++ b/GOGDotNet/GOGClient.cs
@@ -27,7 +27,7 @@ namespace GOGDotNet
         /// </summary>
         /// <param name="userID"></param>
         /// <returns></returns>
-        public async Task<(ProfileState, IEnumerable<Game>)> GetGamesStatsAsync(string userID)
+        public virtual async Task<(ProfileState, IEnumerable<Game>)> GetGamesStatsAsync(string userID)
         {
             if (string.IsNullOrEmpty(userID))
             {

--- a/GOGDotNet/GOGClient.cs
+++ b/GOGDotNet/GOGClient.cs
@@ -1,5 +1,6 @@
 ﻿using GOGDotNet.Models;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using RestSharp;
 using System;
 using System.Collections.Generic;
@@ -61,11 +62,13 @@ namespace GOGDotNet
                     string imageUrl = responseItem?.game?.image?.Value;
                     if (imageUrl != null)
                     {
-                        // Update image URL to get full-size image
-                        imageUrl = imageUrl.Replace(".png", "_prof_game_200x120.png");
+                // Update image URL to get full-size image
+                imageUrl = imageUrl.Replace(".png", "_prof_game_200x120.png");
                     }
 
-                    return new Game()
+
+
+                    var game = new Game()
                     {
                         AchievementSupport = responseItem?.game?.achievementSupport?.Value,
                         Id = ulong.Parse(responseItem?.game?.id?.Value),
@@ -73,6 +76,21 @@ namespace GOGDotNet
                         Title = responseItem?.game?.title?.Value,
                         Url = responseItem?.game?.url?.Value
                     };
+
+                    if (responseItem?.stats != null)
+                    {
+                // stats: []
+                // stats: { "<id>": object }
+                dynamic stats = JToken.FromObject(responseItem?.stats as object).First?.Value<JProperty>()?.Value;
+
+                        game.LastSession = stats?.lastSession?.Value;
+                        game.AchievementsPercentage = stats?.achievementsPercentage?.Value == null
+                    ? null : Convert.ToUInt32(stats?.achievementsPercentage?.Value);
+                        game.Playtime = stats?.playtime?.Value == null
+                    ? null : Convert.ToUInt32(stats?.playtime?.Value);
+                    }
+
+                    return game;
                 }));
             }
 

--- a/GOGDotNet/GOGClient.cs
+++ b/GOGDotNet/GOGClient.cs
@@ -62,8 +62,8 @@ namespace GOGDotNet
                     string imageUrl = responseItem?.game?.image?.Value;
                     if (imageUrl != null)
                     {
-                // Update image URL to get full-size image
-                imageUrl = imageUrl.Replace(".png", "_prof_game_200x120.png");
+                        // Update image URL to get full-size image
+                        imageUrl = imageUrl.Replace(".png", "_prof_game_200x120.png");
                     }
 
 
@@ -79,9 +79,9 @@ namespace GOGDotNet
 
                     if (responseItem?.stats != null)
                     {
-                // stats: []
-                // stats: { "<id>": object }
-                dynamic stats = JToken.FromObject(responseItem?.stats as object).First?.Value<JProperty>()?.Value;
+                        // stats: []
+                        // stats: { "<id>": object }
+                        dynamic stats = JToken.FromObject(responseItem?.stats as object).First?.Value<JProperty>()?.Value;
 
                         game.LastSession = stats?.lastSession?.Value;
                         game.AchievementsPercentage = stats?.achievementsPercentage?.Value == null

--- a/GOGDotNet/GOGClient.cs
+++ b/GOGDotNet/GOGClient.cs
@@ -78,8 +78,6 @@ namespace GOGDotNet
 
                     if (responseItem?.stats != null)
                     {
-                        // stats: []
-                        // stats: { "<id>": object }
                         dynamic stats = JToken.FromObject(responseItem?.stats as object).First?.Value<JProperty>()?.Value;
 
                         game.LastSession = stats?.lastSession?.Value;

--- a/GOGDotNet/GOGClient.cs
+++ b/GOGDotNet/GOGClient.cs
@@ -67,7 +67,6 @@ namespace GOGDotNet
                     }
 
 
-
                     var game = new Game()
                     {
                         AchievementSupport = responseItem?.game?.achievementSupport?.Value,

--- a/GOGDotNet/GOGDotNet.csproj
+++ b/GOGDotNet/GOGDotNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.1.1</Version>
+    <Version>0.2.0</Version>
     <Authors>Matthew Chartier</Authors>
     <Company>Condorcet, LLC</Company>
     <Product>AllMyGames</Product>

--- a/GOGDotNet/Models/Game.cs
+++ b/GOGDotNet/Models/Game.cs
@@ -1,4 +1,6 @@
-﻿namespace GOGDotNet.Models
+﻿using System;
+
+namespace GOGDotNet.Models
 {
     public class Game
     {
@@ -6,6 +8,9 @@
         public string Title { get; set; }
         public string Url { get; set; }
         public bool AchievementSupport { get; set; }
+        public uint? AchievementsPercentage { get; set; }
+        public uint? Playtime { get; set; }
+        public DateTimeOffset? LastSession { get; set; }
         public string Image { get; set; }
     }
 }


### PR DESCRIPTION
Thanks @MChartier, this has been working great. The only thing I needed was the extra `stats` info and since I am writing tests against GOG, I needed to be able to mock `GetGameStatsAsync` so if it's OK, I marked it `virtual` so the mocking framework can overwrite it (otherwise, it could have an interface and that'll work too).

## Changes

- Added stats fields:
  - `AchievementsPercentage`
  - `Playtime` (in hours, I think?)
  - `LastSession`
- Tests for the game data coming back
- Marked `GetGameStatsAsync` as `virtual` for mocking
- Added `.editorconfig` so VS Code wouldn't change tab sizing on save