### PR TITLE
chore!: Upgrade to RestSharp v113

### DIFF
--- a/GOGDotNet.Tests/GOGClientTests.cs
+++ b/GOGDotNet.Tests/GOGClientTests.cs
@@ -22,7 +22,7 @@ namespace GOGDotNet.Tests
             const string userID = "MChartier";
             var response = await this.client.GetGamesStatsAsync(userID);
             Assert.IsNotNull(response);
-            Assert.AreEqual(response.Item1, Models.ProfileState.Verified);
+            Assert.AreEqual(Models.ProfileState.Verified, response.Item1);
 
             var games = response.Item2.ToList();
             var discoElysium = games.FirstOrDefault(g => g.Id == 1771589310);

--- a/GOGDotNet.Tests/GOGDotNet.Tests.csproj
+++ b/GOGDotNet.Tests/GOGDotNet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/GOGDotNet.Tests/GOGDotNet.Tests.csproj
+++ b/GOGDotNet.Tests/GOGDotNet.Tests.csproj
@@ -1,16 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/GOGDotNet/GOGDotNet.csproj
+++ b/GOGDotNet/GOGDotNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.2.0</Version>
+    <Version>1.0.0</Version>
     <Authors>Matthew Chartier</Authors>
     <Company>Condorcet, LLC</Company>
     <Product>AllMyGames</Product>

--- a/GOGDotNet/GOGDotNet.csproj
+++ b/GOGDotNet/GOGDotNet.csproj
@@ -19,8 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.*" />
-    <PackageReference Include="RestSharp" Version="106.*" />
+    <PackageReference Include="RestSharp" Version="110.*" />
   </ItemGroup>
 
 </Project>

--- a/GOGDotNet/GOGDotNet.csproj
+++ b/GOGDotNet/GOGDotNet.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="110.*" />
+    <PackageReference Include="RestSharp" Version="113.0.0" />
   </ItemGroup>
 
 </Project>

--- a/GOGDotNet/GogStatsConverter.cs
+++ b/GOGDotNet/GogStatsConverter.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GOGDotNet.Models;
+
+namespace GOGDotNet
+{
+  /// <summary>
+  /// Converts Gog `stats` property
+  /// </summary>
+  /// <remarks>
+  /// GOG returns an empty array when there are no stats, but an hash map with a single stats object when there are stats.
+  /// </remarks> 
+  public class GogStatsConverter : JsonConverter<Dictionary<string, GogStats>>
+  {
+    public override Dictionary<string, GogStats> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+      if (reader.TokenType == JsonTokenType.StartArray)
+      {
+        reader.Read();
+        if (reader.TokenType == JsonTokenType.EndArray)
+        {
+          return null;
+        }
+
+        throw new JsonException("Expected array or object for stats.");
+      }
+
+      return JsonSerializer.Deserialize<Dictionary<string, GogStats>>(ref reader, options);
+    }
+
+    public override void Write(Utf8JsonWriter writer, Dictionary<string, GogStats> value, JsonSerializerOptions options)
+    {
+      if (value == null || value.Count == 0)
+      {
+        writer.WriteStartArray();
+        writer.WriteEndArray();
+      }
+      else
+      {
+        JsonSerializer.Serialize(writer, value, options);
+      }
+    }
+  }
+}

--- a/GOGDotNet/Models/GamesStatsResponse.cs
+++ b/GOGDotNet/Models/GamesStatsResponse.cs
@@ -1,9 +1,41 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace GOGDotNet.Models
 {
-    public class GamesStatsResponse
+    public class GogGameResponse
     {
-        public IEnumerable<Game> Games { get; set; }
+        public int pages { get; set; }
+        public GogEmbedded _embedded { get; set; }
+    }
+
+    public class GogEmbedded
+    {
+        public List<GogItem> items { get; set; }
+    }
+
+    public class GogItem
+    {
+        public GogGame game { get; set; }
+
+        [JsonConverter(typeof(GogStatsConverter))]
+        public Dictionary<string, GogStats> stats { get; set; }
+    }
+
+    public class GogGame
+    {
+        public string image { get; set; }
+        public string id { get; set; }
+        public string title { get; set; }
+        public string url { get; set; }
+        public bool? achievementSupport { get; set; }
+    }
+
+    public class GogStats
+    {
+        public DateTimeOffset? lastSession { get; set; }
+        public uint? achievementsPercentage { get; set; }
+        public uint? playtime { get; set; }
     }
 }


### PR DESCRIPTION
I had some other dependency upgrades that use RS v113 and this was incompatible. RestSharp v107+ [had breaking changes](https://restsharp.dev/v107/#restsharp-v107), as well as uses `System.Text.Json` as the default JSON serializer.

## BREAKING CHANGES

- Upgrade to RestSharp v113
- Remove `Newtonsoft.Json`

## Changes

- Add support for deserializing as strongly-typed response
- Handle `stats` field with a `GogStatsConverter`
- Upgrade tests to .NET 10 to get rid of warnings

```
Starting test execution, please wait...

A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 823 ms - GOGDotNet.Tests.dll (net7.0)   
```
